### PR TITLE
Add Docker set-up for running benchmarks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.vscode/
+node_modules/
+yarn.lock
+
+docker-compose.yml
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Build code
+FROM node:11-alpine
+
+# Install fresh packages, neat trick:
+# Create new layer, to make sure that changing a code doesn't require installing node modules again
+COPY ./package*.json /tmp/node-cache/
+RUN cd /tmp/node-cache && npm install --no-save
+
+# Copy benchmark code
+COPY . /app
+
+# Copy node modules
+RUN cp -rf /tmp/node-cache/node_modules /app/node_modules
+
+# Start application
+WORKDIR /app
+CMD node index ${SUITE_NAME}

--- a/README.md
+++ b/README.md
@@ -61,9 +61,27 @@ $ yarn
 ```
 
 > For remote test need to install a [NATS](http://nats.io/) server too.
+> You may also use Docker container version of this benchmark.
 
 Start nats server (`gnatsd`) and 
 ```
 $ npm run bench local
 $ npm run bench remote
 ```
+
+### Docker container version
+
+If you don't want to have unneeded dependencies and software on your local computer,
+you may use Docker to set-up "virtual containers" with this benchmark.
+
+#### Prerequisities
+
+You need to have [Docker](https://docs.docker.com/install/) and [docker-compose](https://docs.docker.com/compose/install/) installed.
+
+#### Starting benchmark
+
+Simply run `docker-compose up` command, so:
+
+* NATS server will be set-up
+* All dependencies will be installed
+* Benchmark results will be visible in your terminal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '2'
+
+services:
+  local-benchmark:
+    container_name: benchmark_local
+    restart: on-failure
+    image: micro-benchmark
+    build:
+      dockerfile: Dockerfile
+      context: .
+    environment:
+      SUITE_NAME: local
+    networks:
+      - micro-benchmark
+
+  remote-benchmark:
+    container_name: benchmark_remote
+    restart: on-failure
+    image: micro-benchmark
+    build:
+      dockerfile: Dockerfile
+      context: .
+    environment:
+      SUITE_NAME: remote
+      NATS_URL: nats:4222
+    networks:
+      - micro-benchmark
+    depends_on:
+      - nats
+    links:
+      - nats
+
+  nats:
+    container_name: benchmark_nats
+    image: nats:1.4.1
+    networks:
+      - micro-benchmark
+
+networks:
+  micro-benchmark:
+    driver: bridge

--- a/suites/remote.js
+++ b/suites/remote.js
@@ -7,6 +7,8 @@ let benchmark = new Benchmarkify("Microservices benchmark").printHeader();
 
 const bench = benchmark.createSuite("Call remote actions");
 
+const natsServerUrl = "nats://" + (process.env.NATS_URL || "localhost:4222")
+
 // Moleculer
 let broker1;
 let broker2;
@@ -39,7 +41,7 @@ let hemera2;
 (function () {
 
 	const Hemera = require('nats-hemera');
-	const nats = require('nats').connect("nats://localhost:4222");
+	const nats = require('nats').connect(natsServerUrl);
 
 	hemera1 = new Hemera(nats, { logLevel: 'error' });
 	hemera2 = new Hemera(nats, { logLevel: 'error' });


### PR DESCRIPTION
A lot of people (including me) doesn't want to install external software (like NATS server) locally, so I have prepared Dockerized version of this benchmark.

I made it for my own purposes, but should be enough for everybody :)